### PR TITLE
Return the correct date property

### DIFF
--- a/src/Records/Blocks/BasicBlock.php
+++ b/src/Records/Blocks/BasicBlock.php
@@ -259,6 +259,7 @@ class BasicBlock extends Record implements BlockInterface
                     case 'b':
                         return '**'.trim($text).'**';
                     case 'd':
+                        return $options['start_date'];
                     case 'p':
                         return $text;
                     case 'a':


### PR DESCRIPTION
The date is returned in a weird format from the api. The options
contains an array with a type (date) and a start_date (the actual date
in Y-m-d format). Let's thus return this start_date instead of text.